### PR TITLE
Use black instead of black-translucent for the status bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
   
   <!--iOS web app, deletable if not needed -->
   <!--<meta name="apple-mobile-web-app-capable" content="yes">
-  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <link rel="apple-touch-startup-image" href="img/l/splash.png">-->
   
   <!-- more tags for your 'head' to consider https://gist.github.com/849231 -->


### PR DESCRIPTION
Using black-translucent makes the content of the page appear behind the status bar when the page is displayed fullscreen.

See: http://forum.jquery.com/topic/using-apple-mobile-web-app-capable-to-hide-the-browser-chrome

Hence, using a saner default (like black) might be a better choice.
