### PR TITLE
added preventDefault to fastButton->onClick to remove the delayed blink

### DIFF
--- a/js/mylibs/helper.js
+++ b/js/mylibs/helper.js
@@ -71,6 +71,7 @@ MBP.fastButton.prototype.onTouchMove = function(event) {
 
 MBP.fastButton.prototype.onClick = function(event) {
     event.stopPropagation();
+    event.preventDefault();
     this.reset();
     this.handler(event);
     if(event.type == 'touchend') {


### PR DESCRIPTION
added preventDefault to fastButton->onClick. This removes the annoying extra blink that often shows up, especially on iPhone4.
