### PR TITLE
hide url bar without cutting off top 1px

### DIFF
--- a/js/mylibs/helper.js
+++ b/js/mylibs/helper.js
@@ -27,7 +27,7 @@ MBP.gestureStart = function () {
 
 MBP.hideUrlBar = function () {
     /iPhone/.test(MBP.ua) && !location.hash && setTimeout(function () {
-      pageYOffset || window.scrollTo(0, 1);
+      pageYOffset || window.scrollTo(0, 0);  // scroll without cutting off top 1 pixel
     }, 1000);
 };
 


### PR DESCRIPTION
Lots of folks use window.scrollTo(0,1) because of Remy's post (http://remysharp.com/2010/08/05/doing-it-right-skipping-the-iphone-url-bar/), but there turns out to be no reason (as far as I can tell) to chop off the top pixel, so we should use window.scrollTo(0,0) instead.

I think it's gone unnoticed so long because most folks don't put stuff right at the top without padding/margin.
