### PR TITLE
Added Android support to hideUrlBar

### DIFF
--- a/js/mylibs/helper.js
+++ b/js/mylibs/helper.js
@@ -22,13 +22,36 @@ MBP.gestureStart = function () {
 };
 
 
-// Hide URL Bar for iOS
-// http://remysharp.com/2010/08/05/doing-it-right-skipping-the-iphone-url-bar/
+// Hide URL Bar for iOS and Android by Scott Jehl
+// https://gist.github.com/1183357
 
 MBP.hideUrlBar = function () {
-    /iPhone/.test(MBP.ua) && !location.hash && setTimeout(function () {
-      pageYOffset || window.scrollTo(0, 1);
-    }, 1000);
+	var win = window,
+		doc = win.document;
+
+	// If there's a hash, or addEventListener is undefined, stop here
+	if( !location.hash || !win.addEventListener ){
+
+		//scroll to 1
+		window.scrollTo( 0, 1 );
+		var scrollTop = 1,
+
+		//reset to 0 on bodyready, if needed
+		bodycheck = setInterval(function(){
+			if( doc.body ){
+				clearInterval( bodycheck );
+				scrollTop = "scrollTop" in doc.body ? doc.body.scrollTop : 1;
+				win.scrollTo( 0, scrollTop === 1 ? 0 : 1 );
+			}	
+		}, 15 );
+
+		win.addEventListener( "load", function(){
+			setTimeout(function(){
+				//reset to hide addr bar at onload
+				win.scrollTo( 0, scrollTop === 1 ? 0 : 1 );
+			}, 0);
+		}, false );
+	}
 };
 
 


### PR DESCRIPTION
Replaced hideUrlBar function with Scott Jehl's gist:

[https://gist.github.com/1183357](https://gist.github.com/1183357)

Adds Android support and enables it to fire a bit earlier.
