### PR TITLE
Fixes MBP.hideUrlBar() which executes if addEventListener is undefined

### DIFF
--- a/js/mylibs/helper.js
+++ b/js/mylibs/helper.js
@@ -30,7 +30,7 @@ MBP.hideUrlBar = function () {
 		doc = win.document;
 
 	// If there's a hash, or addEventListener is undefined, stop here
-	if( !location.hash || !win.addEventListener ){
+	if( !location.hash && win.addEventListener ){
 
 		//scroll to 1
 		window.scrollTo( 0, 1 );


### PR DESCRIPTION
Fixes #75: MBP.hideUrlBar() executes if addEventListener is undefined

As documented on https://gist.github.com/1183357#gistcomment-52884, the
hideUrlBar() function is buggy. It will evaluate even if there is no
windows.addEventListener present.
