### PR TITLE
Stop fastButton preventing click events, else you can't use the site on desktop browsers.

### DIFF
--- a/js/mylibs/helper.js
+++ b/js/mylibs/helper.js
@@ -112,7 +112,6 @@ MBP.fastButton.prototype.onTouchMove = function(event) {
 MBP.fastButton.prototype.onClick = function(event) {
 	event = event || window.event;
     if (event.stopPropagation) { event.stopPropagation(); }
-    if (event.preventDefault) { event.preventDefault(); }
     this.reset();
     this.handler(event);
     if(event.type == 'touchend') {


### PR DESCRIPTION
I use `new MBP.fastButton(document.documentElement, function(event) {` along with some basic event delegation so it works on all links. However, the added `event.preventDefault()` meant the site stopped responding to click interactions that didn't also have a touch event, as in regular desktop use.
