### PR TITLE
Tried to make hide url functionality more usefull

### DIFF
--- a/js/helper.js
+++ b/js/helper.js
@@ -28,41 +28,63 @@ MBP.gestureStart = function () {
   * MIT License
 */
 
-MBP.hideUrlBar = function () {
+// If we split this up into two functions we can reuse
+// this function if we aren't doing full page reloads.
+
+// If we cache this we don't need to re-calibrate everytime we call
+// the hide url bar
+MBP.BODY_SCROLL_TOP = false;
+
+// So we don't redefine this function everytime we
+// we call hideUrlBar
+MBP.getScrollTop = function(){
+  var win = window,
+      doc = document;
+
+  return win.pageYOffset || doc.compatMode === "CSS1Compat" && doc.documentElement.scrollTop || doc.body.scrollTop || 0;
+};
+
+// It should be up to the mobile
+MBP.hideUrlBar = function(){
+    var win = window;
+
+    // if there is a hash, or MBP.BODY_SCROLL_TOP hasn't been set yet, wait till that happens
+    if( !location.hash && MBP.BODY_SCROLL_TOP !== false){
+        win.scrollTo( 0, MBP.BODY_SCROLL_TOP === 1 ? 0 : 1 );
+    }
+};
+
+MBP.hideUrlBarOnLoad = function () {
   var win = window,
       doc = win.document;
-	
+
   // If there's a hash, or addEventListener is undefined, stop here
   if( !location.hash && win.addEventListener ) {
-		
+
     //scroll to 1
     window.scrollTo( 0, 1 );
-    var scrollTop = 1,
-        getScrollTop = function() {
-          return win.pageYOffset || doc.compatMode === "CSS1Compat" && doc.documentElement.scrollTop || doc.body.scrollTop || 0;
-        },
-		
-        //reset to 0 on bodyready, if needed
-        bodycheck = setInterval(function() {
-          if( doc.body ) {
-            clearInterval( bodycheck );
-            scrollTop = getScrollTop();
-            win.scrollTo( 0, scrollTop === 1 ? 0 : 1 );
-          }	
-        }, 15 );
-		
+    MBP.BODY_SCROLL_TOP = 1;
+
+    //reset to 0 on bodyready, if needed
+    bodycheck = setInterval(function() {
+      if( doc.body ) {
+        clearInterval( bodycheck );
+        MBP.BODY_SCROLL_TOP = MBP.getScrollTop();
+        MBP.hideUrlBar();
+      }
+    }, 15 );
+
     win.addEventListener( "load", function() {
       setTimeout(function() {
         //at load, if user hasn't scrolled more than 20 or so...
-        if( getScrollTop() < 20 ) {
+        if( MBP.getScrollTop() < 20 ) {
           //reset to hide addr bar at onload
-          win.scrollTo( 0, scrollTop === 1 ? 0 : 1 );
+          MBP.hideUrlBar();
         }
       }, 0);
     } );
   }
-}
-
+};
 
 // Fast Buttons - read wiki below before using
 // https://github.com/h5bp/mobile-boilerplate/wiki/JavaScript-Helper


### PR DESCRIPTION
I have been working on a project where we have paired mbp with jquery-pjax. There are lots of modifications we have made to the base that are specific to our needs, but I thought this one could be useful to others.

Basically there are times when a user does a page load where we know it would be cool to re-hide the url bar.  Also, while the initial behavior is acceptable(move to 1, check if it's interpreted as 0) on the first page load, if you do that every time the user does a page transition it can look like a bug. So, if you cache the value you can alleviate the need to re-check that every time.

I tried to be conscience of style, and tone but I might have missed something in the code it's self. Not sure if this is the best place to make a comment like this as well, so feel free to let me know if I should bring this up somewhere else.
