### PR TITLE
hadTouchEvent needs to run regardless of whether fastButton is used

### DIFF
--- a/js/mylibs/helper.js
+++ b/js/mylibs/helper.js
@@ -83,7 +83,6 @@ MBP.fastButton.prototype.handleEvent = function(event) {
 };
 
 MBP.fastButton.prototype.onTouchStart = function(event) {
-  MBP.hadTouchEvent = true;
   event.stopPropagation();
   this.element.addEventListener('touchend', this, false);
   document.body.addEventListener('touchmove', this, false);
@@ -148,6 +147,10 @@ MBP.ghostClickHandler = function (event) {
 if (document.addEventListener) {
   document.addEventListener('click', MBP.ghostClickHandler, true);
 }
+
+addEvt( document.documentElement, 'touchstart', function() {
+  MBP.hadTouchEvent = true;
+}, false);
                             
 MBP.coords = [];
 


### PR DESCRIPTION
Otherwise the ghostClickHandler will cancel all touch interaction, as hadTouchEvent would be false
