### PR TITLE
Fixing property typo in MBP build script to copy js/libs/*

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -588,7 +588,7 @@
             <exclude name="otherscripts-concat.js"/>
             <exclude name="plugins.js"/>
             <exclude name="${file.root.script}"/>
-            <include name="${slug.lib}/*"/>
+            <include name="${slug.libs}/*"/>
         </fileset>
       </copy>
   </target>


### PR DESCRIPTION
A property typo in MBP build target "-js.all.minify" prevents copying "js/libs/*" to the publish folder.

Fix is changing line 591, "slug.lib" -> "slug.libs"
