### PR TITLE
Use conditional comment for IEMobile-specific meta tag that doesn't validate

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
   <!-- <script>(function(a,b,c){if(c in b&&b[c]){var d,e=a.location,f=/^(a|html)$/i;a.addEventListener("click",function(a){d=a.target;while(!f.test(d.nodeName))d=d.parentNode;"href"in d&&(d.href.indexOf("http")||~d.href.indexOf(e.host))&&(a.preventDefault(),e.href=d.href)},!1)}})(document,window.navigator,"standalone")</script> -->
   
   <!-- Mobile IE allows us to activate ClearType technology for smoothing fonts for easy reading -->
-  <meta http-equiv="cleartype" content="on">
+  <!--[if IEMobile]>  <meta http-equiv="cleartype" content="on">  <![endif]-->
 
   <!-- more tags for your 'head' to consider h5bp.com/d/head-Tips -->
 


### PR DESCRIPTION
index.html is not valid HTML5 because a value of `cleartype` is not permitted for the `http-equiv` attribute in `<meta http-equiv="cleartype">`.  (Either that or http://www.w3.org/TR/html5/semantics.html#attr-meta-http-equiv is out of date, which I suppose is entirely possible since it's a work-in-progress and all that.)

Assuming I'm not completely off base here and that producing valid HTML5 is important to the project, perhaps an acceptable solution is to enclose that invalid markup in a conditional comment like I've done here. 

The comments around the invalid markup already indicate that it's for Mobile IE. 

I believe the conditional comments are only supported on Windows Phone 7 and later, so I guess earlier phones will have to deal without the smoother typefaces. (I'm OK with that personally, but Windows Phones before Windows Phone 7 constitutes a vanishingly small portion of traffic to my sites.)
