### PR TITLE
Tweaking fastclick Android 2.3 fix

### DIFF
--- a/js/helper.js
+++ b/js/helper.js
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * MBP - Mobile boilerplate helper functions
  */
 
@@ -168,7 +168,7 @@ MBP.preventGhostClick = function (x, y) {
 };
 
 MBP.ghostClickHandler = function (event) {
-  if (!MBP.hadTouchEvent && 'ontouchstart' in window) {
+  if (!MBP.hadTouchEvent && MBP.dodgyAndroid) {
     // This is a bit of fun for Android 2.3...
     // If you change window.location via fastButton, a click event will fire
     // on the new page, as if the events are continuing from the previous page.
@@ -188,6 +188,11 @@ MBP.ghostClickHandler = function (event) {
     }
   }
 };
+
+// This bug only affects touch Android 2.3 devices, but a simple ontouchstart test creates a false positive on
+// some Blackberry devices. https://github.com/Modernizr/Modernizr/issues/372
+// The browser sniffing is to avoid the Blackberry case. Bah
+MBP.dodgyAndroid = ('ontouchstart' in window) && (navigator.userAgent.indexOf('Android 2.3') != -1);
 
 if (document.addEventListener) {
   document.addEventListener('click', MBP.ghostClickHandler, true);


### PR DESCRIPTION
The Android 2.3 fastclick fix caused problems on devices that reported to have touch capabilities but didn't fire touch events. This includes some builds of Blackberry 6.0 and iOS using VoiceOver.

We need to restrict this fix to the single OS it's there to fix. Not delighted about the UA sniffing, if anyone can think of a non-sniffy way to do it, that'd be better.

This code is running on http://m.lanyrd.com now if you want to test it. VoiceOver works fine there, the problems with focusing when the page changes are down to us using XHR to switch page, will fix that, but it's unrelated to the fastclick issue. 
