### PR TITLE
Improve solution for #147

### DIFF
--- a/js/helper.js
+++ b/js/helper.js
@@ -374,7 +374,11 @@
 
         //hack to fix letterboxed full screen web apps on 4" iPhone / iPod
         if ((navigator.platform === 'iPhone' || 'iPod') && (screen.height === 568)) {
-            document.querySelector("meta[name=viewport]").content="width=320.1";
+            if (MBP.viewportmeta) {
+                MBP.viewportmeta.content = MBP.viewportmeta.content
+                    .replace(/\bwidth\s*=\s*320\b/, 'width=320.1')
+                    .replace(/\bwidth\s*=\s*device-width\b/, '');
+            }
         }
     };
 


### PR DESCRIPTION
Now it won't clear all other settings in the viewport meta.

It changes `width` to `320.1` if its value is `320`, or removes it if its value is `device-width`.
