### PR TITLE
Update console method to remove function-name from noop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 == HEAD
 
+* Remove named function expression in plugins.js
+
 == 4.1.0
 
 * Update to Normalize.css 2.1.0.

--- a/js/plugins.js
+++ b/js/plugins.js
@@ -1,7 +1,7 @@
 // Avoid `console` errors in browsers that lack a console.
 (function() {
     var method;
-    var noop = function noop() {};
+    var noop = function () {};
     var methods = [
         'assert', 'clear', 'count', 'debug', 'dir', 'dirxml', 'error',
         'exception', 'group', 'groupCollapsed', 'groupEnd', 'info', 'log',


### PR DESCRIPTION
Pulling in the latest changes to that function from HTML5 Boilerplate.
Also I like new line at EOF if this is ok for you :)

References:
h5bp/html5-boilerplate#1280
h5bp/html5-boilerplate@94ec8161d0215203ed3fcd3e0892813abd4f37c3
