### PR TITLE
Improvements to preventZoom function

### DIFF
--- a/js/helper.js
+++ b/js/helper.js
@@ -322,6 +322,7 @@
         var formFields = document.querySelectorAll('input, select, textarea');
         var contentString = 'width=device-width,initial-scale=1,maximum-scale=';
         var i = 0;
+        var fieldLength = formFields.length;
 
         var setViewportOnFocus = function() {
             MBP.viewportmeta.content = contentString + '1';
@@ -331,7 +332,7 @@
             MBP.viewportmeta.content = contentString + '10';
         };
 
-        for (i = 0; i < formFields.length; i++) {
+        for (; i < fieldLength; i++) {
             formFields[i].onfocus = setViewportOnFocus;
             formFields[i].onblur = setViewportOnBlur;
         }


### PR DESCRIPTION
The improvements in here are mostly for performance reasons:
### Reference length of form fields

Use a variable to track the length of the form fields rather than calculating it in every new iteration within the for-loop.
Apart from that I removed the first declaration of `var i` since there were two that both do `i = 0` otherwise.
### Zoom on focus function: move functions outside of loop

Remove creation of onfocus- and onblur-functions from for-loop since this is bad for performance. Instead just call a reference of these functions.
If functions are created within the loop each iteration will get its own function in memory. Calling a function reference has the same effect.
