### PR TITLE
updating pull requests link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,5 +97,5 @@ project:
 9. Push your topic branch up to your fork (`git push origin
    <topic-branch-name>`).
 
-10. [Open a Pull Request](http://help.github.com/send-pull-requests/) with a
+10. [Open a Pull Request](https://help.github.com/articles/using-pull-requests) with a
     clear title and description. Please mention which browsers you tested in.


### PR DESCRIPTION
have contributors who want to learn more about contributing go [here](https://help.github.com/articles/using-pull-requests) instead of [here](https://help.github.com/articles/sending-pull-requests) in the `contributing.md`.

this is the [same error](https://github.com/h5bp/html5-boilerplate/pull/1308) that was fixed in the html5 boilerplate
