### PR TITLE
404.html remove IE 6 _width hack

### DIFF
--- a/404.html
+++ b/404.html
@@ -31,7 +31,6 @@
 
             body {
                 max-width: 500px;
-                _width: 500px;
                 padding: 30px 20px 50px;
                 border: 1px solid #b3b3b3;
                 border-radius: 4px;
@@ -65,7 +64,6 @@
 
             .container {
                 max-width: 380px;
-                _width: 380px;
                 margin: 0 auto;
             }
 


### PR DESCRIPTION
Better to remove 404.html extra _width hack for desktop version of the IE 6.
