### PR TITLE
ghostClickHandler no longer listened for by default

### DIFF
--- a/js/helper.js
+++ b/js/helper.js
@@ -100,6 +100,8 @@
         // styling of .pressed is defined in the project's CSS files
         this.pressedClass = typeof pressedClass === 'undefined' ? 'pressed' : pressedClass;
 
+        MBP.listenForGhostClicks();
+
         if (element.length && element.length > 1) {
             for (var singleElIdx in element) {
                 this.addClickEvent(element[singleElIdx]);
@@ -201,13 +203,24 @@
     // The browser sniffing is to avoid the Blackberry case. Bah
     MBP.dodgyAndroid = ('ontouchstart' in window) && (navigator.userAgent.indexOf('Android 2.3') != -1);
 
-    if (document.addEventListener) {
-        document.addEventListener('click', MBP.ghostClickHandler, true);
-    }
+    MBP.listenForGhostClicks = (function() {
+        var alreadyRan = false;
 
-    addEvt(document.documentElement, 'touchstart', function() {
-        MBP.hadTouchEvent = true;
-    }, false);
+        return function() {
+            if(alreadyRan) {
+                return;
+            }
+
+            if (document.addEventListener) {
+                document.addEventListener('click', MBP.ghostClickHandler, true);
+            }
+            addEvt(document.documentElement, 'touchstart', function() {
+                MBP.hadTouchEvent = true;
+            }, false);
+
+            alreadyRan = true;
+        };
+    })();
 
     MBP.coords = [];
 


### PR DESCRIPTION
I had a situation where I want to use some but not all of the utilities in `helper.js`. In particular, I am using the FTLabs `fastclick` library so do not need fastbutton.

Currently an event listener is added for ghostClickHandler, even if you don't need it. This patch only adds this event listener when it is needed, i.e. when a FastButton is instantiated for the first time.

A simple `alreadyRan` check is included to ensure that the event is only added on the first FastButton invocation.
