### PR TITLE
Remove need to readjust margins in `404.html`

### DIFF
--- a/404.html
+++ b/404.html
@@ -7,22 +7,23 @@
     <style>
 
         * {
-            line-height: 1.5;
+            line-height: 1.2;
             margin: 0;
         }
 
         html {
             color: #888;
+            display: table;
             font-family: sans-serif;
+            height: 100%;
             text-align: center;
+            width: 100%;
         }
 
         body {
-            left: 50%;
-            margin: -43px 0 0 -150px;
-            position: absolute;
-            top: 50%;
-            width: 300px;
+            display: table-cell;
+            vertical-align: middle;
+            margin: 2em auto;
         }
 
         h1 {
@@ -32,19 +33,19 @@
         }
 
         p {
-            line-height: 1.2;
+            margin: 0 auto;
+            width: 280px;
         }
 
-        @media only screen and (max-width: 270px) {
+        @media only screen and (max-width: 280px) {
 
-            body {
-                margin: 10px auto;
-                position: static;
+            body, p {
                 width: 95%;
             }
 
             h1 {
                 font-size: 1.5em;
+                margin: 0 0 0.3em 0;
             }
 
         }


### PR DESCRIPTION
Since some of the users prefer to just modify the placeholder 404
page instead of replacing it with their own, this commit makes it
easier to do that by allowing them to modify the content without
worrying about readjusting the margins.

Recently changed in html5-boilerplate repo too: https://github.com/h5bp/html5-boilerplate/commit/c3a72ff882104a1abc6ed05f5ca3eabb11c08a51
