### PR TITLE
Use short version of shorthand for margin declaration in 404.html

### DIFF
--- a/404.html
+++ b/404.html
@@ -45,7 +45,7 @@
 
             h1 {
                 font-size: 1.5em;
-                margin: 0 0 0.3em 0;
+                margin: 0 0 0.3em;
             }
 
         }


### PR DESCRIPTION
This minor fix is recently committed to html5-boilerplate repo too: https://github.com/h5bp/html5-boilerplate/commit/a44c533d55624e69065f6173d67ff91e9027949c
