### PR TITLE
Add `timeline` & `timelineEnd` in `plugins.js`

### DIFF
--- a/js/plugins.js
+++ b/js/plugins.js
@@ -6,7 +6,7 @@
         'assert', 'clear', 'count', 'debug', 'dir', 'dirxml', 'error',
         'exception', 'group', 'groupCollapsed', 'groupEnd', 'info', 'log',
         'markTimeline', 'profile', 'profileEnd', 'table', 'time', 'timeEnd',
-        'timeStamp', 'trace', 'warn'
+        'timeline', 'timelineEnd', 'timeStamp', 'trace', 'warn'
     ];
     var length = methods.length;
     var console = (window.console = window.console || {});


### PR DESCRIPTION
Added 2 methods to the script in `plugins.js`:
- `timeline`
  https://developer.chrome.com/devtools/docs/console-api#consoletimelinelabel
- `timelineEnd`
  https://developer.chrome.com/devtools/docs/console-api#consoletimestamplabel
