### PR TITLE
Docs: Remove `tools` folder from file tree in usage.md

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -36,8 +36,6 @@ A basic Mobile Boilerplate site initially looks something like this:
 │   └── vendor
 │       ├── modernizr-2.8.3.min.js
 │       └── jquery-2.1.1.min.js
-├── tools
-│   └── [mobile-bookmark-bubble]
 ├── .htaccess
 ├── 404.html
 ├── index.html


### PR DESCRIPTION
The `tools` folder is removed in https://github.com/h5bp/mobile-boilerplate/commit/be0d77f5c5340951544e40a715e94311e09a8e2d. But the folder was still in the file tree of `doc/usage.md`.
